### PR TITLE
Don't copy callee

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,24 +30,17 @@ Hello, world!
 
 ## How It Works
 
-We can write a program like this:
+When `ctts script.ts` is executed, compile-time-typescript creates a caller like this:
 
 ```typescript
-type Main<Input extends string> = `Hello, ${Input}\n`;
-export default Main;
-```
-
-Compile-time-typescript saves the program as `callee.ts` and creates `caller.ts`:
-
-```typescript
-import Main from './callee';
+import Main from '/path/to/script';
 type Input = "HERE COMES THE INPUT";
 type Output = Main<Input>;
 ```
 
 So the program must have a default export of a generic type that takes a type parameter and constructs a string literal type.
 
-Then compile-time-typescript type-checks `caller.ts` and extracts the type information of `Output`.
+Then compile-time-typescript type-checks the caller and extracts the type information of `Output`.
 
 If `Output` is a string literal type, its content is printed. Otherwise, an error occurs.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import { promises as fs } from 'fs';
 import * as tmp from 'tmp-promise';
 import * as path from 'path';
 
+tmp.setGracefulCleanup();
+
 interface RunOptions {
   input: Buffer;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,21 +12,19 @@ interface RunResult {
 }
 
 export async function run(fileName: string, { input = Buffer.of() }: Partial<RunOptions> = {}): Promise<RunResult> {
-  const { path: tmpDirPath } = await tmp.dir({ prefix: `compile-time-typescript` });
-  const callerFileName = `caller.ts`;
-  const callerPath = path.join(tmpDirPath, callerFileName);
-  await fs.writeFile(callerPath, `
+  const { path: callerFileName, cleanup } = await tmp.file({ prefix: `compile-time-typescript`, postfix: `caller.ts` });
+  await fs.writeFile(callerFileName, `
     import Main from ${JSON.stringify(path.resolve(fileName).replace(/\.ts$/, ''))};
     type Input = ${JSON.stringify(input.toString('binary'))};
     type Output = Main<Input>;
   `);
   const program = ts.createProgram({
-    rootNames: [callerPath],
+    rootNames: [callerFileName],
     options: {
       strict: true,
     },
   });
-  const source = program.getSourceFile(callerPath)!;
+  const source = program.getSourceFile(callerFileName)!;
   const checker = program.getTypeChecker();
   const outputList: Buffer[] = [];
 
@@ -44,8 +42,7 @@ export async function run(fileName: string, { input = Buffer.of() }: Partial<Run
   }
 
   source.forEachChild(visit);
-  await fs.unlink(callerPath);
-  await fs.rmdir(tmpDirPath);
+  await cleanup();
   return {
     output: Buffer.concat(outputList),
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,12 +13,10 @@ interface RunResult {
 
 export async function run(fileName: string, { input = Buffer.of() }: Partial<RunOptions> = {}): Promise<RunResult> {
   const { path: tmpDirPath } = await tmp.dir({ prefix: `compile-time-typescript` });
-  const calleeFileName = `callee.ts`;
   const callerFileName = `caller.ts`;
   await Promise.all([
-    fs.copyFile(fileName, path.join(tmpDirPath, calleeFileName)),
     fs.writeFile(path.join(tmpDirPath, callerFileName), `
-      import Main from './${path.basename(calleeFileName, path.extname(calleeFileName))}';
+      import Main from ${JSON.stringify(path.resolve(fileName).replace(/\.ts$/, ''))};
       type Input = ${JSON.stringify(input.toString('binary'))};
       type Output = Main<Input>;
     `),
@@ -48,7 +46,6 @@ export async function run(fileName: string, { input = Buffer.of() }: Partial<Run
 
   source.forEachChild(visit);
   await Promise.all([
-    fs.unlink(path.join(tmpDirPath, calleeFileName)),
     fs.unlink(path.join(tmpDirPath, callerFileName)),
   ]);
   await fs.rmdir(tmpDirPath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,13 +15,11 @@ export async function run(fileName: string, { input = Buffer.of() }: Partial<Run
   const { path: tmpDirPath } = await tmp.dir({ prefix: `compile-time-typescript` });
   const callerFileName = `caller.ts`;
   const callerPath = path.join(tmpDirPath, callerFileName);
-  await Promise.all([
-    fs.writeFile(callerPath, `
-      import Main from ${JSON.stringify(path.resolve(fileName).replace(/\.ts$/, ''))};
-      type Input = ${JSON.stringify(input.toString('binary'))};
-      type Output = Main<Input>;
-    `),
-  ]);
+  await fs.writeFile(callerPath, `
+    import Main from ${JSON.stringify(path.resolve(fileName).replace(/\.ts$/, ''))};
+    type Input = ${JSON.stringify(input.toString('binary'))};
+    type Output = Main<Input>;
+  `);
   const program = ts.createProgram({
     rootNames: [callerPath],
     options: {
@@ -46,9 +44,7 @@ export async function run(fileName: string, { input = Buffer.of() }: Partial<Run
   }
 
   source.forEachChild(visit);
-  await Promise.all([
-    fs.unlink(callerPath),
-  ]);
+  await fs.unlink(callerPath);
   await fs.rmdir(tmpDirPath);
   return {
     output: Buffer.concat(outputList),


### PR DESCRIPTION
`callee` を `/tmp` にコピーする必要がない？

- 他ファイルのインポートが可能になる
- もともと esolang-box 用に他ファイルのインポートを禁止する予定だったが、
  - どうせ他ファイルは作れない
  - 他ファイルをインポートできたほうが楽しみ方が広がる（型のライブラリ化など）
  - もともと絶対パスでのインポートが可能だった
- そのうち `caller` もわざわざファイルを作らないようにすれば、一時ファイルが不要になる
- TypeScript Compiler API のパス解決などについてもう少し理解する必要がある